### PR TITLE
added multiple image size suppport

### DIFF
--- a/hymm_sp/data_kits/audio_dataset.py
+++ b/hymm_sp/data_kits/audio_dataset.py
@@ -104,7 +104,16 @@ class VideoAudioTextLoaderVal(Dataset):
         new_h = round(h * scale / 64) * 64
 
         if img_size == 704:
-            img_size_long = 1216
+            img_size_long = 1216 
+        elif img_size == 512:
+            img_size_long = 768
+        elif img_size == 384:
+            img_size_long = 576
+        elif img_size == 256:
+            img_size_long = 384
+        else:
+            img_size_long = img_size * 1.5  # Default fallback
+
         if new_w * new_h > img_size * img_size_long:
             import math
             scale = math.sqrt(img_size * img_size_long / w / h)


### PR DESCRIPTION
HunyuanVideo-Avatar/hymm_sp/data_kits/audio_dataset.py throws error at line 108 when provided different image size. To reproduce this error run below code - 

CUDA_VISIBLE_DEVICES=0 python3 hymm_sp/sample_gpu_poor.py \
    --input 'assets/test.csv' \
    --ckpt ${checkpoint_path} \
    --sample-n-frames 129 \
    --seed 128 \
    --image-size 512 \
    --cfg-scale 7.5 \
    --infer-steps 30 \
    --use-deepcache 1 \
    --flow-shift-eval-video 5.0 \
    --save-path ${OUTPUT_BASEPATH} \
    --use-fp8 \
    --cpu-offload \
    --infer-min


should throw this error: UnboundLocalError: local variable 'img_size_long' referenced before assignment